### PR TITLE
Fix MC_THREAD_SIG handler replacement during thread recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all : minicriu libminicriu-client.a
 
 minicriu : minicriu.o
 minicriu : LDFLAGS += -static
+minicriu : LDLIBS += -lpthread
 minicriu.o : CFLAGS += -fPIE
 
 minicriu-client.o : CFLAGS += -fPIC

--- a/minicriu.c
+++ b/minicriu.c
@@ -116,10 +116,6 @@ static void restore(int sig, siginfo_t *info, void *ctx) {
 
 	pthread_barrier_wait(&thread_barrier);
 
-	if (!thread_id) {
-		pthread_barrier_destroy(&thread_barrier);
-	}
-
 #if 0
 	if (thread_id == 0) {
 		munmap(rawelf, elfsz);


### PR DESCRIPTION
Add thread synchronization during recovery in order to avoid MC_THREAD_SIG handler replacement. Now all threads are calling the desired MC_THREAD_SIG handler.